### PR TITLE
Fix Ruff F401 in test helpers

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,3 @@
-import array
 import os
 import random
 import wave


### PR DESCRIPTION
## Summary
- remove an unused `array` import from `tests/test_helpers.py` to satisfy Ruff (`F401`).

## Why
- the previous merge (`#22`) introduced this import as dead code, causing the `Lint` workflow to fail on `main`.

## Validation
- `uv run --with ruff ruff check src tests` -> pass
- `uv run --with pytest pytest -q tests` -> `151 passed, 1 warning`
